### PR TITLE
Tighten regex on numeric param validation

### DIFF
--- a/src/routes/demo/demo.routes.js
+++ b/src/routes/demo/demo.routes.js
@@ -14,5 +14,5 @@ export const demoRouter = koaRouter()
     demo)
   .get(
     '/foo-must-be-numeric',
-    validateParams(['query'], ['foo'], match(/[0-9]/)),
+    validateParams(['query'], ['foo'], match(/^[0-9]*$/)),
     demo);

--- a/src/routes/demo/demo.spec.js
+++ b/src/routes/demo/demo.spec.js
@@ -24,9 +24,15 @@ describe('Health check', () => {
         .expect(200, 'It works!');
     });
 
-    it('should result in a 400 if the parameter is invalid', () => {
+    it('should result in a 400 if the parameter is not numeric', () => {
       return request.get('/demo/foo-must-be-numeric')
         .query({ foo: 'abc' })
+        .expect(400, 'foo is invalid.');
+    });
+
+    it('should result in a 400 if the parameter mixes numbers with letters', () => {
+      return request.get('/demo/foo-must-be-numeric')
+        .query({ foo: 'abc123' })
         .expect(400, 'foo is invalid.');
     });
 


### PR DESCRIPTION
It was possible to send `abc123` and have it pass the regex, so I've fixed that and added a test.

#hacktoberfest