### PR TITLE
Refactor and add routes to get coverage to 100%

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-preset-es2015": "^6.1.4",
     "debug": "^2.2.0",
     "koa": "^2.0.0",
+    "koa-bodyparser": "^2.2.0",
     "koa-helmet": "^2.0.0-alpha.1",
     "koa-morgan": "^1.0.1",
     "koa-router": "^7.0.1",

--- a/src/app.js
+++ b/src/app.js
@@ -1,33 +1,38 @@
 import Koa from 'koa';
 import koaRouter from 'koa-router';
+import bodyParser from 'koa-bodyparser';
 import helmet from 'koa-helmet';
 import winston from 'winston';
 import { errorResponder } from './middleware/error-responder';
 import { REQUEST_LOGS } from './project-env';
+import { rootRouter } from './routes/root.routes';
 import { healthCheckRouter } from './routes/health-check/health-check.routes';
 import { demoRouter } from './routes/demo/demo.routes';
 
 // Entry point for all modules.
 const api = koaRouter()
-  .get('/', ctx => ctx.body = 'API Koa Starter from Rangle.io')
+  .get('/', rootRouter.routes())
   .use('/health', healthCheckRouter.routes())
   .use('/demo', demoRouter.routes());
 
 // Top level server configuration.
 export const app = new Koa();
 
+/* istanbul ignore if */
 if (REQUEST_LOGS) {
   app.use(require('koa-morgan')('combined'));
 }
 
 app
   .use(helmet())
+  .use(bodyParser())
   .use(errorResponder)
   .use(api.routes())
   .use(api.allowedMethods());
 
 const PORT = process.env.PORT || 3000;
 
+/* istanbul ignore if */
 if (require.main === module) {
   winston.info(`Starting server on port ${PORT}`);
   app.listen(PORT);

--- a/src/project-env.js
+++ b/src/project-env.js
@@ -1,6 +1,7 @@
 const { PROJECT_ENV } = process.env;
 const ENV_WHITELIST = ['local', 'testing', 'staging'];
 
+/* istanbul ignore if */
 if (!PROJECT_ENV || ENV_WHITELIST.includes(PROJECT_ENV) === -1) {
   throw new Error(`PROJECT_ENV: must be one of ${ENV_WHITELIST}`);
 }

--- a/src/routes/demo/demo.controller.js
+++ b/src/routes/demo/demo.controller.js
@@ -1,3 +1,20 @@
 export async function demo(ctx) {
   ctx.body = 'It works!';
 }
+
+/**
+ * Demo Error Responder: Deliberataly return 500 error for testing.
+ */
+export async function error(ctx) {
+  ctx.status = 500;
+  ctx.message = 'App Error (this is intentional)!';
+}
+
+/**
+ * Demo Error Responder: Deliberataly return 500 error without message for testing.
+ */
+export async function errorWithoutMessage() {
+  // eslint-disable-next-line no-console
+  console.log('About to throw an error deliberately, ignore it.');
+  throw new Error('');
+}

--- a/src/routes/demo/demo.routes.js
+++ b/src/routes/demo/demo.routes.js
@@ -1,5 +1,5 @@
 import koaRouter from 'koa-router';
-import { demo } from './demo.controller';
+import { demo, error, errorWithoutMessage } from './demo.controller';
 import { validateParams } from '../../middleware/validate-params';
 
 const match = regex => term => regex.test(term);
@@ -15,4 +15,11 @@ export const demoRouter = koaRouter()
   .get(
     '/foo-must-be-numeric',
     validateParams(['query'], ['foo'], match(/^[0-9]*$/)),
-    demo);
+    demo)
+  .post(
+    '/body-must-have-foo-with-bar',
+    validateParams(['request', 'body', 'foo'], ['bar']),
+    demo)
+  .get('/error', error)
+  .get('/error-without-message', errorWithoutMessage);
+

--- a/src/routes/demo/demo.spec.js
+++ b/src/routes/demo/demo.spec.js
@@ -3,7 +3,7 @@ import { app } from '../../app';
 
 const request = supertest.agent(app.listen());
 
-describe('Health check', () => {
+describe('Demo', () => {
   describe('GET /demo/foo-is-required', () => {
     it('should work if the parameter is present', () => {
       return request.get('/demo/foo-is-required')
@@ -39,6 +39,46 @@ describe('Health check', () => {
     it('should result in a 400 if the parameter is missing', () => {
       return request.get('/demo/foo-must-be-numeric')
         .expect(400, 'foo is required.');
+    });
+  });
+
+  describe('POST /demo/body-must-have-foo-with-bar', () => {
+    it('should work if the body has foo with bar', () => {
+      return request.post('/demo/body-must-have-foo-with-bar')
+        .send({
+          foo: {
+            bar: 'abc',
+          },
+        })
+        .expect(200, 'It works!');
+    });
+
+    it('should result in a 400 is foo container is missing', () => {
+      return request.post('/demo/body-must-have-foo-with-bar')
+        .send({})
+        .expect(400, 'Bad request');
+    });
+
+    it('should result in a 400 is foo container does not have bar', () => {
+      return request.post('/demo/body-must-have-foo-with-bar')
+        .send({
+          foo: { },
+        })
+        .expect(400, 'bar is required.');
+    });
+  });
+
+  describe('GET /demo/error', () => {
+    it('should result in 500 app error response', () => {
+      return request.get('/demo/error')
+        .expect(500, 'App Error (this is intentional)!');
+    });
+  });
+
+  describe('GET /demo/error-without-message', () => {
+    it('should result in 500 app error response', () => {
+      return request.get('/demo/error-without-message')
+        .expect(500, '');
     });
   });
 });

--- a/src/routes/root.controller.js
+++ b/src/routes/root.controller.js
@@ -1,0 +1,6 @@
+/**
+ * Root GET Handler: Just return the API name.
+ */
+export async function root(ctx) {
+  ctx.body = 'API Koa Starter from Rangle.io';
+}

--- a/src/routes/root.routes.js
+++ b/src/routes/root.routes.js
@@ -1,0 +1,8 @@
+import koaRouter from 'koa-router';
+import { root } from './root.controller';
+
+/**
+ * Root routes: just return the API name.
+ */
+export const rootRouter = koaRouter()
+  .get('/', root);

--- a/src/routes/root.spec.js
+++ b/src/routes/root.spec.js
@@ -1,0 +1,13 @@
+import supertest from 'supertest-as-promised';
+import { app } from '../app';
+
+const request = supertest.agent(app.listen());
+
+describe('Root', () => {
+  describe('GET /', () => {
+    it('should result in API name response', () => {
+      return request.get('/')
+        .expect(200, 'API Koa Starter from Rangle.io');
+    });
+  });
+});


### PR DESCRIPTION
Added new root route handler to make function testable.
Added new deliberate error-creating routes to get coverage on error handling middleware.
Added new endpoint with JSON body params to get coverage on the check for the param container in middleware.
Feat: for the above had to add `koa-bodyparser` for json body data support.
Had to ignore some untestable (to my knowledge) ENV checks.

Code coverage is now **100%** across the board with only a few ignores. I can also update this when my other PRs get merged.