### PR TITLE
Enable prod cluster with throng

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "koa-morgan": "^1.0.1",
     "koa-router": "^7.0.1",
     "ramda": "^0.22.1",
+    "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "uuid": "^3.0.1",
     "winston": "^2.2.0"
@@ -66,7 +67,8 @@
     "rimraf": "^2.5.3",
     "sinon": "^1.17.3",
     "supertest": "^2.0.0",
-    "supertest-as-promised": "^4.0.1"
+    "supertest-as-promised": "^4.0.1",
+    "throng": "^4.0.0"
   },
   "nyc": {
     "check-coverage": true,

--- a/src/app.js
+++ b/src/app.js
@@ -11,38 +11,46 @@ import { rootRouter } from './routes/root.routes';
 import { healthCheckRouter } from './routes/health-check/health-check.routes';
 import { demoRouter } from './routes/demo/demo.routes';
 
-// Entry point for all modules.
-const api = koaRouter()
-  .get('/', rootRouter.routes())
-  .use('/health', healthCheckRouter.routes())
-  .use('/demo', demoRouter.routes());
+function setUpServer(app) {
+  // Entry point for all modules.
+  const api = koaRouter()
+    .get('/', rootRouter.routes())
+    .use('/health', healthCheckRouter.routes())
+    .use('/demo', demoRouter.routes());
 
-// Top level server configuration.
-export const app = new Koa();
+  app.use(generateRequestId);
 
-app.use(generateRequestId);
+  /* istanbul ignore if */
+  if (k.REQUEST_LOGS) {
+    const morgan = require('koa-morgan');
+    const format = '[RQID=:request-id] - :remote-user' +
+      ' [:date[clf]] ":method :url HTTP/:http-version" ' +
+      ':status :res[content-length] ":referrer" ":user-agent"';
+    morgan.token('request-id', req => req.requestId);
+    app.use(morgan(format));
+  }
 
-/* istanbul ignore if */
-if (k.REQUEST_LOGS) {
-  const morgan = require('koa-morgan');
-  const format = '[RQID=:request-id] - :remote-user' +
-    ' [:date[clf]] ":method :url HTTP/:http-version" ' +
-    ':status :res[content-length] ":referrer" ":user-agent"';
-  morgan.token('request-id', req => req.requestId);
-  app.use(morgan(format));
+  app
+    .use(helmet())
+    .use(koaConvert(bodyParser()))
+    .use(errorResponder)
+    .use(api.routes())
+    .use(api.allowedMethods());
+
+  return app;
 }
 
-app
-  .use(helmet())
-  .use(koaConvert(bodyParser()))
-  .use(errorResponder)
-  .use(api.routes())
-  .use(api.allowedMethods());
-
-const PORT = process.env.PORT || 3000;
-
-/* istanbul ignore if */
-if (require.main === module) {
+function startFunction() {
+  const app = setUpServer(new Koa());
+  const PORT = process.env.PORT || 3000;
   logger.info(`Starting server on port ${PORT}`);
   app.listen(PORT);
 }
+/* istanbul ignore if */
+if (require.main === module) {
+  const throng = require('throng');
+  throng(startFunction);
+}
+
+// Top level server configuration.
+export const app = setUpServer(new Koa());


### PR DESCRIPTION
Connected to https://github.com/rangle/rangle-starter/issues/145.

After looking through `throng` and `koa-cluster`, I am inclined to think that `pm2` is a better way for clustering in the prod mode. Unless is there any other special requirements? @SethDavenport 